### PR TITLE
Filter out iframes without a replaceId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-info",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "",
   "main": "dist/main.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -231,6 +231,9 @@ function extractIframes (page) {
       if (err) {
         reject(err)
       } else {
+        // filter out empty replace id iframes
+        iframesData = iframesData.filter((iframe) => iframe.replaceId !== '')
+
         resolve({
           numResourcesRequested: page.resourcesRequested.length,
           resourcesRequested: page.resourcesRequested,


### PR DESCRIPTION
- Do not send updates to the vault for iframes without a non-blank replaceId
- Bumped npm version number
